### PR TITLE
Attempt to fix lover message displayed before death

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3096,7 +3096,7 @@ namespace Werewolf_Node
                 {
                     p.IsDead = true;
                     p.TimeDied = DateTime.Now;
-                    Send(GetLocaleString("LoverDied", victim.GetName(), p.GetName(), DbGroup.ShowRoles == false ? "" : $"{p.GetName()} {GetLocaleString("Was")} {GetDescription(p.PlayerRole)}"), ChatId);
+                    SendWithQueue(GetLocaleString("LoverDied", victim.GetName(), p.GetName(), DbGroup.ShowRoles == false ? "" : $"{p.GetName()} {GetLocaleString("Was")} {GetDescription(p.PlayerRole)}"));
                     DBKill(victim, p, KillMthd.LoverDied);
                 }
             }


### PR DESCRIPTION
In some cases, lover death is still displayed before death of loved one. Though in fact I didn't read that much about Send and SendWithQueue, I hope this works, if that worked in the other cases... Sorry if it was a useless commit