### PR TITLE
Fix Won and Lost string not used

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -2643,7 +2643,7 @@ namespace Werewolf_Node
                         msg = Players.Where(x => !x.IsDead)
                             .OrderBy(x => x.Team)
                             .Aggregate(msg,
-                                (current, p) => current + $"\n{p.GetName()}: {GetDescription(p.PlayerRole)} ({p.Team} Team) {(p.InLove ? "❤️" : "")} {(p.Won ? "Won" : "Lost")}");
+                                (current, p) => current + $"\n{p.GetName()}: {GetDescription(p.PlayerRole)} ({p.Team} Team) {(p.InLove ? "❤️" : "")} {(p.Won ? GetLocaleString("Won") : GetLocaleString("Lost"))}");
                         break;
                 }
                 if (game.TimeStarted.HasValue)


### PR DESCRIPTION
they weren't used if Show Roles at Game End is set to "Show only living players"