### PR TITLE
Fixed strings for English.

### DIFF
--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -54,7 +54,7 @@
   <string key="PMTheBot">
     <!-- 0 - Player name -->
     <!-- 1 - bot username -->
-    <value>{0} click this: @{1}, then click start.  Until you do, I cannot tell you what your role is.</value>
+    <value>{0} click this: {1}, then click start.  Until you do, I cannot tell you what your role is.</value>
   </string>
   <string key="DeadFlee">
     <value>You can't run away! YOU'RE DEAD!  Get back in the ground....  jeez</value>

--- a/Werewolf for Telegram/Languages/EnglishNSFW.xml
+++ b/Werewolf for Telegram/Languages/EnglishNSFW.xml
@@ -43,7 +43,7 @@
     <value>{0} has joined the game. {1} players, {2} minimum, {3} max</value>
   </string>
   <string key="PMTheBot">
-    <value>{0} click this: @{1}, then click start.  Until you do, I cannot tell you what your role is.</value>
+    <value>{0} click this: {1}, then click start.  Until you do, I cannot tell you what your role is.</value>
   </string>
   <string key="DeadFlee">
     <value>You can't run away! YOU'RE DEAD!  Get back in the ground....  jeez, zombies these days</value>


### PR DESCRIPTION
Multiple other languages need this fix too.

 {1} already has an "@"
"@{1}" results in "@@username"

![werewolfboterror](https://cloud.githubusercontent.com/assets/17110029/17306603/8f652a48-584e-11e6-9c5b-e61bea4ca753.png)
