### PR TITLE
Fix /start command adding people in DB multiple times

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
@@ -197,7 +197,7 @@ namespace Werewolf_Control
                             {
                                 UserName = usr.Username,
                                 Name = (usr.FirstName + " " + usr.LastName).Trim(),
-                                TelegramId = u.Id,
+                                TelegramId = usr.Id,
                                 Language = "English"
                             };
                             db.Players.Add(p);


### PR DESCRIPTION
People were registered with the "/start" message id instead of their Telegram id. Not a big issue for the algorithm, but this would save a bit of space in the database