### PR TITLE
Extend command

### DIFF
--- a/Werewolf for Telegram/Database/Group.cs
+++ b/Werewolf for Telegram/Database/Group.cs
@@ -45,7 +45,8 @@ namespace Database
         public string Description { get; set; }
         public string GroupLink { get; set; }
         public Nullable<int> MemberCount { get; set; }
-    
+        public Nullable<bool> AllowExtend { get; set; }
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<Game> Games { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1113,12 +1113,12 @@
   <string key="SecondsAdded">
     <!-- 0 - Seconds added by /extend command -->
     <!-- 1 - Total seconds remaining -->
-    <value>Join time extended by {0} seconds!\n{1} seconds left to /join</value>
+    <value>Join time extended by {0} seconds!\n{1} left to /join</value>
   </string>
   <string key="SecondsRemoved">
     <!-- 0 - Seconds removed by /extend command -->
     <!-- 1 - Total seconds remaining -->
-     <value>Join time decreased by {0} seconds!\n{1} seconds left to /join</value>
+     <value>Join time decreased by {0} seconds!\n{1} left to /join</value>
   </string>
   <string key="AllowExtendQ">
     <value>Allow players to extend join time?\nCurrent: {0}\nNote: players who didn't join still won't be able to extend join timer.</value>

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1113,6 +1113,6 @@
   <string key="SecondsAdded">
     <!-- 0 - Seconds added by /extend command -->
     <!-- 1 - Total seconds remaining -->
-    <value>Join time extended by {0} seconds!\n{1} seconds left to /join</value>
+    <value>Join time extended by {0} seconds!</value>
   </string>
 </strings>

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1120,5 +1120,11 @@
     <!-- 1 - Total seconds remaining -->
      <value>Join time decreased by {0} seconds!\n{1} seconds left to /join</value>
   </string>
-
+  <string key="AllowExtendQ">
+    <value>Allow players to extend join time?\nCurrent: {0}\nNote: players who didn't join still won't be able to extend join timer.</value>
+  </string>
+  <string key="AllowExtendA">
+    <!--{0} = "Allow" / "Disallow" string-->
+    <value>{0} players to extend join time</value>
+  </string>
 </strings>

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1115,4 +1115,10 @@
     <!-- 1 - Total seconds remaining -->
     <value>Join time extended by {0} seconds!\n{1} seconds left to /join</value>
   </string>
+  <string key="SecondsRemoved">
+    <!-- 0 - Seconds removed by /extend command -->
+    <!-- 1 - Total seconds remaining -->
+     <value>Join time decreased by {0} seconds!\n{1} seconds left to /join</value>
+  </string>
+
 </strings>

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1113,6 +1113,6 @@
   <string key="SecondsAdded">
     <!-- 0 - Seconds added by /extend command -->
     <!-- 1 - Total seconds remaining -->
-    <value>Join time extended by {0} seconds!</value>
+    <value>Join time extended by {0} seconds!\n{1} seconds left to /join</value>
   </string>
 </strings>

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -1110,4 +1110,9 @@
     <!-- 0 - Group Name -->
     <value>You have successfully joined the game in {0}</value>
   </string>
+  <string key="SecondsAdded">
+    <!-- 0 - Seconds added by /extend command -->
+    <!-- 1 - Total seconds remaining -->
+    <value>Join time extended by {0} seconds!\n{1} seconds left to /join</value>
+  </string>
 </strings>

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -154,7 +154,7 @@ namespace Werewolf_Control
             }
         }
 
-        [Command(Trigger = "Extend", Blockable = true, InGroupOnly = true)]
+        [Command(Trigger = "extend", Blockable = true, InGroupOnly = true)]
         public static void Extend(Update update, string[] args)
         {
             var id = update.Message.Chat.Id;
@@ -175,8 +175,7 @@ namespace Werewolf_Control
                     game?.ExtendTime(seconds);
 
                     return;
-                }
-                if (node != null)
+                } else
                 {
                     //there is a game, but this player is not in it
                     Send(GetLocaleString("NotPlaying", GetLanguage(id)), id);

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -171,8 +171,9 @@ namespace Werewolf_Control
                 if (game?.Users.Contains(update.Message.From.Id) ?? UpdateHelper.IsGroupAdmin(update))
                 {
                     int seconds;
+                    bool admin = UpdateHelper.IsGroupAdmin(update);
                     seconds = int.TryParse(args[1], out seconds) ? seconds : 30;
-                    game?.ExtendTime(seconds);
+                    game?.ExtendTime(seconds, admin);
 
                     return;
                 } else

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -152,8 +152,40 @@ namespace Werewolf_Control
             {
                 Send(GetLocaleString("NoGame", GetLanguage(id)), id);
             }
+        }
 
+        [Command(Trigger = "Extend", Blockable = true, InGroupOnly = true)]
+        public static void Extend(Update update, string[] args)
+        {
+            var id = update.Message.Chat.Id;
+            //check nodes to see if player is in a game
+            var node = GetPlayerNode(update.Message.From.Id);
+            var game = GetGroupNodeAndGame(update.Message.Chat.Id);
+            if (game != null || node != null)
+            {
+                //try grabbing the game again...
+                if (node != null)
+                    game =
+                        node.Games.FirstOrDefault(
+                            x => x.Users.Contains(update.Message.From.Id));
+                if (game?.Users.Contains(update.Message.From.Id) ?? UpdateHelper.IsGroupAdmin(update) && game?.State == 0)
+                {
+                    int seconds;
+                    seconds = int.TryParse(args[1], out seconds) ? seconds : 30;
+                    game?.ExtendTime(seconds);
 
+                    return;
+                }
+                if (node != null)
+                {
+                    //there is a game, but this player is not in it
+                    Send(GetLocaleString("NotPlaying", GetLanguage(id)), id);
+                }
+            }
+            else
+            {
+                Send(GetLocaleString("NoGame", GetLanguage(id)), id);
+            }
         }
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -168,7 +168,7 @@ namespace Werewolf_Control
                     game =
                         node.Games.FirstOrDefault(
                             x => x.Users.Contains(update.Message.From.Id));
-                if (game?.Users.Contains(update.Message.From.Id) ?? UpdateHelper.IsGroupAdmin(update) && game?.State == 0)
+                if (game?.Users.Contains(update.Message.From.Id) ?? UpdateHelper.IsGroupAdmin(update))
                 {
                     int seconds;
                     seconds = int.TryParse(args[1], out seconds) ? seconds : 30;

--- a/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
@@ -166,7 +166,8 @@ namespace Werewolf_Control
                 AllowCult = true,
                 DisableFlee = false,
                 MaxPlayers = 35,
-                CreatedBy = createdBy
+                CreatedBy = createdBy,
+                AllowExtend = false,
             };
         }
 

--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -981,6 +981,21 @@ namespace Werewolf_Control.Handler
                                 GetLocaleString("WhatToDo", language), replyMarkup: GetConfigMenu(groupid));
                             DB.SaveChanges();
                             break;
+                        case "extend":
+                            buttons.Add(new InlineKeyboardButton(GetLocaleString("Allow", language), $"setextend|{groupid}|true"));
+                            buttons.Add(new InlineKeyboardButton(GetLocaleString("Disallow", language), $"setextend|{groupid}|false"));
+                            buttons.Add(new InlineKeyboardButton(Cancel, $"setcult|{groupid}|cancel"));
+                            menu = new InlineKeyboardMarkup(buttons.Select(x => new[] { x }).ToArray());
+                            Edit(query.Message.Chat.Id, query.Message.MessageId,
+                                GetLocaleString("AllowExtendQ", language, grp.AllowExtend == false ? GetLocaleString("Disallow", language) : GetLocaleString("Allow", language)), replyMarkup: menu);
+                            break;
+                        case "setextend":
+                            grp.AllowExtend = (choice == "true");
+                            Bot.Api.AnswerCallbackQuery(query.Id, GetLocaleString("AllowExtendA", language, grp.AllowExtend == false ? GetLocaleString("Disallow", language) : GetLocaleString("Allow", language)));
+                            Edit(query.Message.Chat.Id, query.Message.MessageId,
+                                GetLocaleString("WhatToDo", language), replyMarkup: GetConfigMenu(groupid));
+                            DB.SaveChanges();
+                            break;
                         case "done":
                             Edit(query.Message.Chat.Id, query.Message.MessageId,
                                 GetLocaleString("ThankYou", language));
@@ -1050,7 +1065,8 @@ namespace Werewolf_Control.Handler
                 AllowCult = true,
                 DisableFlee = false,
                 MaxPlayers = 35,
-                CreatedBy = createdBy
+                CreatedBy = createdBy,
+                AllowExtend = false,
             };
         }
 
@@ -1071,6 +1087,7 @@ namespace Werewolf_Control.Handler
             buttons.Add(new InlineKeyboardButton("Allow Fool", $"fool|{id}"));
             buttons.Add(new InlineKeyboardButton("Allow Tanner", $"tanner|{id}"));
             buttons.Add(new InlineKeyboardButton("Allow Cult", $"cult|{id}"));
+            buttons.Add(new InlineKeyboardButton("Allow Extending Timer", $"extend|{id}"));
             buttons.Add(new InlineKeyboardButton("Done", $"done|{id}"));
             var twoMenu = new List<InlineKeyboardButton[]>();
             for (var i = 0; i < buttons.Count; i++)

--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -984,7 +984,7 @@ namespace Werewolf_Control.Handler
                         case "extend":
                             buttons.Add(new InlineKeyboardButton(GetLocaleString("Allow", language), $"setextend|{groupid}|true"));
                             buttons.Add(new InlineKeyboardButton(GetLocaleString("Disallow", language), $"setextend|{groupid}|false"));
-                            buttons.Add(new InlineKeyboardButton(Cancel, $"setcult|{groupid}|cancel"));
+                            buttons.Add(new InlineKeyboardButton(Cancel, $"setextend|{groupid}|cancel"));
                             menu = new InlineKeyboardMarkup(buttons.Select(x => new[] { x }).ToArray());
                             Edit(query.Message.Chat.Id, query.Message.MessageId,
                                 GetLocaleString("AllowExtendQ", language, grp.AllowExtend == false ? GetLocaleString("Disallow", language) : GetLocaleString("Allow", language)), replyMarkup: menu);

--- a/Werewolf for Telegram/Werewolf Control/Models/GameInfo.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/GameInfo.cs
@@ -82,11 +82,11 @@ namespace Werewolf_Control.Models
             n?.Broadcast(json);
         }
 
-        public void ExtendTime(int seconds)
+        public void ExtendTime(int seconds, bool admin)
         {
             var n = Bot.Nodes.FirstOrDefault(x => x.ClientId == NodeId);
             if (n == null) return;
-            var json = JsonConvert.SerializeObject(new ExtendTimeInfo() { GroupId = GroupId , Seconds = seconds});
+            var json = JsonConvert.SerializeObject(new ExtendTimeInfo() { GroupId = GroupId , Seconds = seconds, Admin = admin});
             n?.Broadcast(json);
         }
     }

--- a/Werewolf for Telegram/Werewolf Control/Models/GameInfo.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/GameInfo.cs
@@ -81,6 +81,14 @@ namespace Werewolf_Control.Models
             var json = JsonConvert.SerializeObject(new GameKillInfo() { GroupId = GroupId });
             n?.Broadcast(json);
         }
+
+        public void ExtendTime(int seconds)
+        {
+            var n = Bot.Nodes.FirstOrDefault(x => x.ClientId == NodeId);
+            if (n == null) return;
+            var json = JsonConvert.SerializeObject(new ExtendTimeInfo() { GroupId = GroupId , Seconds = seconds});
+            n?.Broadcast(json);
+        }
     }
 
     public enum GameState

--- a/Werewolf for Telegram/Werewolf Control/Models/TcpInfoClasses.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/TcpInfoClasses.cs
@@ -121,5 +121,6 @@ namespace Werewolf_Control.Models
         public string JType { get; set; } = "ExtendTimeInfo";
         public long GroupId { get; set; }
         public int Seconds { get; set; }
+        public bool Admin { get; set; }
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Models/TcpInfoClasses.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/TcpInfoClasses.cs
@@ -115,4 +115,11 @@ namespace Werewolf_Control.Models
         public string JType { get; set; } = "GameKillInfo";
         public long GroupId { get; set; }
     }
+
+    public class ExtendTimeInfo
+    {
+        public string JType { get; set; } = "ExtendTimeInfo";
+        public long GroupId { get; set; }
+        public int Seconds { get; set; }
+    }
 }

--- a/Werewolf for Telegram/Werewolf Node/Helpers/Settings.cs
+++ b/Werewolf for Telegram/Werewolf Node/Helpers/Settings.cs
@@ -130,7 +130,8 @@ namespace Werewolf_Node
             SerialKillerConversionChance = 20,
 #endif
 
-            GameJoinTime = 180;
+            GameJoinTime = 180,
+            ExtendMaxValue = 300;
 
 
 

--- a/Werewolf for Telegram/Werewolf Node/Helpers/Settings.cs
+++ b/Werewolf for Telegram/Werewolf Node/Helpers/Settings.cs
@@ -131,6 +131,7 @@ namespace Werewolf_Node
 #endif
 
             GameJoinTime = 180,
+            MaxJoinTime = 600,
             ExtendMaxValue = 300;
 
 

--- a/Werewolf for Telegram/Werewolf Node/Models/TcpInfoClasses.cs
+++ b/Werewolf for Telegram/Werewolf Node/Models/TcpInfoClasses.cs
@@ -111,4 +111,11 @@ namespace Werewolf_Node.Models
         public string JType { get; set; } = "GameKillInfo";
         public long GroupId { get; set; }
     }
+
+    public class ExtendTimeInfo
+    {
+        public string JType { get; set; } = "ExtendTimeInfo";
+        public long GroupId { get; set; }
+        public int Seconds { get; set; }
+    }
 }

--- a/Werewolf for Telegram/Werewolf Node/Models/TcpInfoClasses.cs
+++ b/Werewolf for Telegram/Werewolf Node/Models/TcpInfoClasses.cs
@@ -117,5 +117,6 @@ namespace Werewolf_Node.Models
         public string JType { get; set; } = "ExtendTimeInfo";
         public long GroupId { get; set; }
         public int Seconds { get; set; }
+        public bool Admin { get; set; }
     }
 }

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -195,7 +195,7 @@ namespace Werewolf_Node
                             case "ExtendTimeInfo":
                                 var eti = JsonConvert.DeserializeObject<ExtendTimeInfo>(msg);
                                 game = Games.FirstOrDefault(x => x.ChatId == eti.GroupId);
-                                game?.ExtendTime(eti.Seconds);
+                                game?.ExtendTime(eti.Seconds, eti.Admin);
                                 break;
                             default:
                                 Console.WriteLine(msg);

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -192,6 +192,11 @@ namespace Werewolf_Node
                                 game = Games.FirstOrDefault(x => x.ChatId == gki.GroupId);
                                 game?.Kill();
                                 break;
+                            case "ExtendTimeInfo":
+                                var eti = JsonConvert.DeserializeObject<ExtendTimeInfo>(msg);
+                                game = Games.FirstOrDefault(x => x.ChatId == eti.GroupId);
+                                game?.ExtendTime(eti.Seconds);
+                                break;
                             default:
                                 Console.WriteLine(msg);
                                 break;

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -209,9 +209,21 @@ namespace Werewolf_Node
                     }
                     if (SecondsToAdd != 0)
                     {
+                        if (Math.Abs(SecondsToAdd) > Settings.ExtendMaxValue)
+                            SecondsToAdd = Settings.ExtendMaxValue * SecondsToAdd / Math.Abs(SecondsToAdd);
                         i -= SecondsToAdd;
-                        var remaining = Settings.GameJoinTime - i; //TODO: Convert remaining seconds to mm:ss (and change string)
-                        SendWithQueue(GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold()));
+                        var msg = "";
+                        var remaining = Settings.GameJoinTime - i;
+                        if (SecondsToAdd > 0)
+                             msg = GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold());
+                        else
+                        {
+                            SecondsToAdd = -SecondsToAdd;
+                            msg = GetLocaleString("SecondsRemoved", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold());
+                        }
+                        if (remaining > 0)
+                            SendWithQueue(msg); //TODO: Convert remaining seconds to mm:ss in the string (and change the strings)
+
                         SecondsToAdd = 0;
                     }
                     Thread.Sleep(1000);

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -210,7 +210,7 @@ namespace Werewolf_Node
                     if (SecondsToAdd != 0)
                     {
                         i -= SecondsToAdd;
-                        var remaining = Settings.GameJoinTime - i
+                        var remaining = Settings.GameJoinTime - i; //TODO: Convert remaining seconds to mm:ss (and change string)
                         SendWithQueue(GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold()));
                         SecondsToAdd = 0;
                     }
@@ -1657,8 +1657,7 @@ namespace Werewolf_Node
         }
         public void ExtendTime(int seconds)
         {
-            if (!IsJoining)
-                return;
+            if (!IsJoining) return;
             SecondsToAdd = seconds;
             return;
         }

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -211,18 +211,18 @@ namespace Werewolf_Node
                     {
                         if (Math.Abs(SecondsToAdd) > Settings.ExtendMaxValue)
                             SecondsToAdd = Settings.ExtendMaxValue * SecondsToAdd / Math.Abs(SecondsToAdd);
-                        i -= SecondsToAdd;
+                        i = Math.Max(i - SecondsToAdd, Settings.GameJoinTime - Settings.MaxJoinTime);
                         var msg = "";
-                        var remaining = Settings.GameJoinTime - i;
+                        var remaining = TimeSpan.FromSeconds(Settings.GameJoinTime - i);
                         if (SecondsToAdd > 0)
-                             msg = GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold());
+                             msg = GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString(@"mm\:ss").ToBold());
                         else
                         {
                             SecondsToAdd = -SecondsToAdd;
-                            msg = GetLocaleString("SecondsRemoved", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold());
+                            msg = GetLocaleString("SecondsRemoved", SecondsToAdd.ToString().ToBold(), remaining.ToString(@"mm\:ss").ToBold());
                         }
-                        if (remaining > 0)
-                            SendWithQueue(msg); //TODO: Convert remaining seconds to mm:ss in the string (and change the strings)
+                        if (Settings.GameJoinTime > i)
+                            SendWithQueue(msg);
 
                         SecondsToAdd = 0;
                     }

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -26,7 +26,8 @@ namespace Werewolf_Node
     class Werewolf : IDisposable
     {
         public long ChatId;
-        public int GameDay, GameId;
+        public int GameDay, GameId, 
+            SecondsToAdd = 0;
         public List<IPlayer> Players = new List<IPlayer>();
         public bool IsRunning,
             IsJoining = true,
@@ -205,6 +206,13 @@ namespace Werewolf_Node
                     if (i == 170)
                     {
                         SendWithQueue(GetLocaleString("SecondsLeftToJoin", "10".ToBold()));
+                    }
+                    if (SecondsToAdd != 0)
+                    {
+                        i -= SecondsToAdd;
+                        var remaining = Settings.GameJoinTime - i
+                        SendWithQueue(GetLocaleString("SecondsAdded", SecondsToAdd.ToString().ToBold(), remaining.ToString().ToBold()));
+                        SecondsToAdd = 0;
                     }
                     Thread.Sleep(1000);
                 }
@@ -1647,7 +1655,13 @@ namespace Werewolf_Node
         {
             KillTimer = true;
         }
-
+        public void ExtendTime(int seconds)
+        {
+            if (!IsJoining)
+                return;
+            SecondsToAdd = seconds;
+            return;
+        }
         private void LynchCycle()
         {
             if (!IsRunning) return;

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1667,9 +1667,14 @@ namespace Werewolf_Node
         {
             KillTimer = true;
         }
-        public void ExtendTime(int seconds)
+        public void ExtendTime(int seconds, bool admin)
         {
             if (!IsJoining) return;
+            if (!admin && DbGroup.AllowExtend == false)
+            {
+                SendWithQueue(GetLocaleString("GroupAdminOnly"));
+                return;
+            }
             SecondsToAdd = seconds;
             return;
         }


### PR DESCRIPTION
Usage: /extend `<seconds>`. Only group admins, or players who have already joined, can run the command.
Extends joining time. Negative values are allowed to decrease time.
