### PR TITLE
Fix for GA/Wolf Kill Message Duping

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Models/IPlayer.cs
+++ b/Werewolf for Telegram/Werewolf Node/Models/IPlayer.cs
@@ -70,6 +70,7 @@ namespace Werewolf_Node.Models
         public bool DiedFromKiller { get; set; } = false;
         public bool DiedFromHunter { get; set; } = false;
         public bool DiedFromLove { get; set; } = false;
+        public bool DiedGuardingWolf { get; set; } = false;
         public int MessageId { get; set; }
         public string Name { get; set; }
         public IRole OriginalRole { get; set; }

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1922,7 +1922,7 @@ namespace Werewolf_Node
                 if (Players == null) return;
                 if (DbGroup.ShowRoles != false)
                 {
-                    foreach (var p in Players.Where(x => x.DiedLastNight && x.DiedFromWolf))
+                    foreach (var p in Players.Where(x => x.DiedLastNight && x.DiedFromWolf && !x.DiedGuardingWolf))
                     {
                         string msg;
                         switch (p.PlayerRole)
@@ -2690,6 +2690,7 @@ namespace Werewolf_Node
                             ga.TimeDied = DateTime.Now;
                             ga.DiedLastNight = true;
                             ga.DiedFromWolf = true;
+                            ga.DiedGuardingWolf = true;
                             DBKill(save, ga, KillMthd.GuardWolf);
                             Send(GetLocaleString("GuardWolf"), ga.Id);
                         }


### PR DESCRIPTION
There is a small dupe bug when the GA guards a wolf on the same night the wolf decides to eat the GA. The GA death message goes out immediately but nothing is set to indicate that the GA is already dead, so a second GA death message is sent during the start of DayCycle(). This patch corrects this by setting a new value, DiedGuardingWolf, to true during the night cycle and checking to make sure it's false during DayCycle to prevent the dupe.

TG: @GRAVYLORD