### PR TITLE
Fix Wolf hunted by SK message

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -2875,8 +2875,11 @@ namespace Werewolf_Node
                                 case IRole.Wolf: //sk and hunter can kill
                                     if (p.KilledByRole == IRole.SerialKiller)
                                     {
-                                        msg = GetLocaleString("SerialKillerKilledWolf", p.GetName());
-                                        //TODO Add visited vs hunted by killer
+                                        //visited vs hunted by killer
+                                        if (p.DiedByVisitingKiller)
+                                            msg = GetLocaleString("SerialKillerKilledWolf", p.GetName());
+                                        else
+                                            msg = GetLocaleString("DefaultKilled", p.GetName());
                                     }
                                     else //died from hunter
                                     {


### PR DESCRIPTION
When a wolf was hunted by SK, the node sends the SerialKillerKilledWolf message to the group, which is wrong.