### PR TITLE
Enable CH in Cult and forbid sole sorcerer

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1278,6 +1278,13 @@ namespace Werewolf_Node
                     SetRoleAttributes();
                 }
 
+				//make sure Sorcerer doesn't play on its own
+				if (Players.Any(x => x.PlayerRole == IRole.Sorcerer) && Players.All(x => !WolfRoles.Contains(x.PlayerRole))) {
+					// turn Sorcerer into Wolf
+					var sorc = Players.First(x => x.PlayerRole == IRole.Sorcerer);
+					sorc.PlayerRole = WolfRoles[Program.R.Next(3)];
+					SetRoleAttributes();
+				}
 
                 foreach (var p in Players)
                     p.OriginalRole = p.PlayerRole;

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1269,16 +1269,14 @@ namespace Werewolf_Node
                 //    }
                 //}
 
-                ////check that CH exists if cult exist
-                //if (Players.Any(x => x.PlayerRole == IRole.Cultist) && Players.All(x => x.PlayerRole != IRole.CultistHunter))
-                //{
-                //    //fix dat shit
-                //    var ch = Players.First(x => x.PlayerRole != IRole.Cultist && x.PlayerRole != IRole.Wolf);
-                //    ch.PlayerRole = IRole.CultistHunter;
-                //    ch.HasDayAction = false;
-                //    ch.HasNightAction = true;
-                //    ch.Team = ITeam.Village;
-                //}
+                //check that CH exists if cult exist
+                if (Players.Any(x => x.PlayerRole == IRole.Cultist) && Players.All(x => x.PlayerRole != IRole.CultistHunter))
+                {
+                    //fix dat shit
+                    var ch = Players.First(x => x.PlayerRole != IRole.Cultist && x.PlayerRole != IRole.Wolf);
+                    ch.PlayerRole = IRole.CultistHunter;
+                    SetRoleAttributes();
+                }
 
 
                 foreach (var p in Players)


### PR DESCRIPTION
Enables the existing check for there being a Cultist Hunter if Cultists are around.

Also adds similar check so that there cannot be a game that has a Sorcerer but no Wolves. If a Sorcerer exists without at least one wolf, the sorcerer is turned into a wolf instead.