### PR TITLE
Fix #152

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3696,8 +3696,8 @@ namespace Werewolf_Node
                 }
                 //reset drunk status
                 player.Drunk = false;
-                _silverSpread = false;
-            }
+            } // alive players foreach
+            _silverSpread = false;
         }
 
         #endregion


### PR DESCRIPTION
Reset _silverSpread outside of player loop, to ensure all Wolves are affected by silver for the night, instead of only the first Wolf.