### PR TITLE
Add /rolelist to the help command

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
@@ -41,7 +41,7 @@ namespace Werewolf_Control
         [Command(Trigger = "help")]
         public static void Help(Update update, string[] args)
         {
-            Bot.Api.SendTextMessage(update.Message.Chat.Id, "[Website](http://www.tgwerewolf.com/?referrer=help)\n[Telegram Werewolf Support Group](http://telegram.me/werewolfsupport)\n[Telegram Werewolf Dev Channel](https://telegram.me/werewolfdev)",
+            Bot.Api.SendTextMessage(update.Message.Chat.Id, "[Website](http://www.tgwerewolf.com/?referrer=help)\n/rolelist (don't forget to /setlang first!)\n[Telegram Werewolf Support Group](http://telegram.me/werewolfsupport)\n[Telegram Werewolf Dev Channel](https://telegram.me/werewolfdev)",
                                                         parseMode: ParseMode.Markdown);
         }
 


### PR DESCRIPTION
Suggested by @Peterpaiter, seeing as the website has no translated role explanations. Now using the /help command will return a message with the previous links, plus the /rolelist command.