### PR TITLE
Fix DG->Traitor->Wolf's check for alive alpha/cub

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1565,7 +1565,7 @@ namespace Werewolf_Node
                                 p.HasDayAction = false;
                                 p.HasNightAction = false;
                                 p.Team = ITeam.Village;
-                                if (Players.Count(x => !x.IsDead && x.PlayerRole == IRole.Wolf) == 0)
+                                if (Players.Count(x => !x.IsDead && WolfRoles.Contains(x.PlayerRole)) == 0)
                                 {
                                     p.HasNightAction = true;
                                     p.PlayerRole = IRole.Wolf;


### PR DESCRIPTION
Fix when DG turned Traitor, turned to wolf directly while there is still alive alpha/cub