### PR TITLE
Correct Clumsy Guy random lynching every turn. Fixes #184

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -625,7 +625,7 @@ namespace Werewolf_Node
 
                 if (player.PlayerRole == IRole.ClumsyGuy && player.CurrentQuestion.QType == QuestionType.Lynch)
                 {
-                    if (Program.R.Next(50) < 100)
+                    if (Program.R.Next(100) < 50)
                     {
                         //pick a random target
                         player.Choice = ChooseRandomPlayerId(player, false);


### PR DESCRIPTION
Currently the Clumsy Guy always lynches randomly (might randomly lynch the one he actually selects) because of the broken always true conditional. Fixed the conditional.