### PR TITLE
Fixes about Role Changes

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1523,8 +1523,14 @@ namespace Werewolf_Node
                         //notify other wolves
                         p.PlayerRole = rm.OriginalRole;
                         if (rm.OriginalRole == IRole.ApprenticeSeer || rm.OriginalRole == IRole.WildChild || rm.OriginalRole == IRole.Traitor || rm.OriginalRole == IRole.Cursed)
+                        {
+                          //if (rm.OriginalRole == IRole.ApprenticeSeer || rm.OriginalRole == IRole.Cursed)
+                            if (rm.OriginalRole == IRole.ApprenticeSeer)     //if cursed turned wolf before dying, should DG turn cursed or directly wolf? use the above line if DG should turn cursed
+                                if (rm.PlayerRole != IRole.Wolf)
+                                    p.PlayerRole = rm.PlayerRole;
                             if (rm.PlayerRole != IRole.Cultist)
                                 p.PlayerRole = rm.PlayerRole;
+                        }
                         p.ChangedRolesCount++;
                         switch (p.PlayerRole)
                         {

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -2086,6 +2086,7 @@ namespace Werewolf_Node
                     Send(msg, p.Id);
                 }
             }
+            CheckRoleChanges();     //so maybe if seer got converted to wolf, appseer will promote here
             if (CheckForGameEnd()) return;
             var nightTime = (DbGroup.NightTime ?? Settings.TimeNight);
             if (GameDay == 1)


### PR DESCRIPTION
For https://github.com/parabola949/Werewolf/commit/def4b178f48d599ca63702f416feb3826ae021b3
added CheckRoleChanges at NightCycle so for example appseer would promote when the seer is alpha-converted

For https://github.com/parabola949/Werewolf/commit/96a4dc1616b9d513640a6407fc3e2d3b6166c34d
If AppSeer (or even Cursed) turned wolf before dying, DG should turn to their original role instead of directly into wolf, Para please decide if its well-balanced for these 2 roles to have such behaviour